### PR TITLE
Users card rfid patch

### DIFF
--- a/inventory-backend/controllers/users.py
+++ b/inventory-backend/controllers/users.py
@@ -45,7 +45,7 @@ def create_user(user_data: NewUserDAO):
 
 
 @router.post("/users/card", tags=["users"])
-def update_user_rfid_card(card_data: NewCardDAO):
-    user = updt_users_card(card_data.id, card_data)
+def update_user_rfid_card(card_data: NewCardDAO, current_user: User = Depends(get_current_active_user)):
+    user = updt_users_card(current_user.id, card_data)
 
     return user

--- a/inventory-backend/schemas/card.py
+++ b/inventory-backend/schemas/card.py
@@ -1,8 +1,6 @@
 from pydantic.main import BaseModel
-from typing import Optional
 
 
 class NewCardDAO(BaseModel):
-    id: int
     rfid: str
     pin: int


### PR DESCRIPTION
There was a security issue because anybody could send any integer as id and change a real user's rfid & pin.

I updated your `users/card` endpoint to require login, get the user id from the same authenticated user, and removed user id from card schema.
